### PR TITLE
Support running FitNesse test suites which use Fixture Interactions through the Junit Test Runner

### DIFF
--- a/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
+++ b/src/fitnesse/testsystems/slim/InProcessSlimClientBuilder.java
@@ -22,7 +22,9 @@ public class InProcessSlimClientBuilder extends ClientBuilder<SlimClient> {
   public SlimClient build() {
     final SlimService.Options options = SlimService.parseCommandLine(getSlimFlags());
     Integer statementTimeout = options != null ? options.statementTimeout : null;
-    SlimServer slimServer = createSlimServer(statementTimeout, isDebug());
+    FixtureInteraction interaction = options != null ? options.interaction : JavaSlimFactory.createInteraction(null);
+
+    SlimServer slimServer = createSlimServer(interaction, statementTimeout, isDebug());
     return new InProcessSlimClient(getTestSystemName(), slimServer, getExecutionLogListener());
   }
 
@@ -31,8 +33,7 @@ public class InProcessSlimClientBuilder extends ClientBuilder<SlimClient> {
     return "in-process";
   }
 
-  protected SlimServer createSlimServer(Integer timeout, boolean verbose) {
-    FixtureInteraction interaction = JavaSlimFactory.createInteraction(null);
+  protected SlimServer createSlimServer(FixtureInteraction interaction, Integer timeout, boolean verbose) {
     return JavaSlimFactory.createJavaSlimFactory(interaction, timeout, verbose).getSlimServer();
   }
 

--- a/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
@@ -1,0 +1,81 @@
+package fitnesse.testsystems.slim;
+
+import fitnesse.slim.fixtureInteraction.DefaultInteraction;
+import fitnesse.slim.fixtureInteraction.FixtureInteraction;
+import fitnesse.slim.fixtureInteraction.InteractionDemo;
+import fitnesse.testsystems.Descriptor;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InProcessSlimClientBuilderTest {
+  @Before
+  public void setUp() throws Exception {
+    // Enforce the test runner here, to make sure we're talking to the right system
+    SlimClientBuilder.clearSlimPortOffset();
+  }
+
+  @Test
+  public void parseInteractionFlags() {
+    Descriptor descriptor = mock(Descriptor.class);
+    when(descriptor.getVariable("slim.flags")).thenReturn("-i "+InteractionDemo.class.getName());
+
+    InProcessSlimClientBuilder slimClientBuilder = new InProcessSlimClientBuilder(descriptor);
+
+    // Check that the arguments were processed correctly and are in the client
+    // builder's slim flags
+    String[] found = slimClientBuilder.getSlimFlags();
+    assertNotNull(found);
+    assertEquals(2, found.length);
+    assertEquals("-i", found[0]);
+    assertEquals(InteractionDemo.class.getName(), found[1]);
+  }
+
+  @Test
+  public void createSlimClientWithFixtureInteraction()  {
+    Descriptor descriptor = mock(Descriptor.class);
+    when(descriptor.getVariable("slim.flags")).thenReturn("-i "+InteractionDemo.class.getName());
+
+    InProcessSlimClientBuilder slimClientBuilder = spy(new InProcessSlimClientBuilder(descriptor));
+
+    // Capture the interaction to see if it's the right one
+    ArgumentCaptor<FixtureInteraction> interactionCaptor = ArgumentCaptor.forClass(FixtureInteraction.class);
+
+    slimClientBuilder.build();
+    verify(slimClientBuilder).createSlimServer(interactionCaptor.capture(), anyInt(), anyBoolean());
+    FixtureInteraction interaction = interactionCaptor.getValue();
+
+    assertNotNull(interaction);
+    assertNotEquals(DefaultInteraction.class, interaction.getClass());
+    assertTrue(interaction instanceof InteractionDemo);
+  }
+
+  @Test
+  public void createSlimClientWithoutFixtureInteraction() throws Exception {
+    Descriptor descriptor = spy(Descriptor.class);
+    when(descriptor.getVariable("slim.flags")).thenReturn(null);
+
+    InProcessSlimClientBuilder slimClientBuilder = spy(new InProcessSlimClientBuilder(descriptor));
+
+    // Capture the interaction to see if it's the right one
+    ArgumentCaptor<FixtureInteraction> interactionCaptor = ArgumentCaptor.forClass(FixtureInteraction.class);
+
+    slimClientBuilder.build();
+    verify(slimClientBuilder).createSlimServer(interactionCaptor.capture(), anyInt(), anyBoolean());
+    FixtureInteraction interaction = interactionCaptor.getValue();
+
+    assertNotNull(interaction);
+    assertEquals(DefaultInteraction.class, interaction.getClass());
+  }
+}

--- a/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
@@ -8,16 +8,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class InProcessSlimClientBuilderTest {
   @Before
@@ -29,7 +23,7 @@ public class InProcessSlimClientBuilderTest {
   @Test
   public void parseInteractionFlags() {
     Descriptor descriptor = mock(Descriptor.class);
-    when(descriptor.getVariable("slim.flags")).thenReturn("-i "+InteractionDemo.class.getName());
+    when(descriptor.getVariable("slim.flags")).thenReturn("-i " + InteractionDemo.class.getName());
 
     InProcessSlimClientBuilder slimClientBuilder = new InProcessSlimClientBuilder(descriptor);
 
@@ -43,9 +37,9 @@ public class InProcessSlimClientBuilderTest {
   }
 
   @Test
-  public void createSlimClientWithFixtureInteraction()  {
+  public void createSlimClientWithFixtureInteraction() {
     Descriptor descriptor = mock(Descriptor.class);
-    when(descriptor.getVariable("slim.flags")).thenReturn("-i "+InteractionDemo.class.getName());
+    when(descriptor.getVariable("slim.flags")).thenReturn("-i " + InteractionDemo.class.getName());
 
     InProcessSlimClientBuilder slimClientBuilder = spy(new InProcessSlimClientBuilder(descriptor));
 

--- a/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
+++ b/test/fitnesse/testsystems/slim/InProcessSlimClientBuilderTest.java
@@ -41,14 +41,7 @@ public class InProcessSlimClientBuilderTest {
     Descriptor descriptor = mock(Descriptor.class);
     when(descriptor.getVariable("slim.flags")).thenReturn("-i " + InteractionDemo.class.getName());
 
-    InProcessSlimClientBuilder slimClientBuilder = spy(new InProcessSlimClientBuilder(descriptor));
-
-    // Capture the interaction to see if it's the right one
-    ArgumentCaptor<FixtureInteraction> interactionCaptor = ArgumentCaptor.forClass(FixtureInteraction.class);
-
-    slimClientBuilder.build();
-    verify(slimClientBuilder).createSlimServer(interactionCaptor.capture(), anyInt(), anyBoolean());
-    FixtureInteraction interaction = interactionCaptor.getValue();
+    FixtureInteraction interaction = captureInteraction(descriptor);
 
     assertNotNull(interaction);
     assertNotEquals(DefaultInteraction.class, interaction.getClass());
@@ -60,16 +53,19 @@ public class InProcessSlimClientBuilderTest {
     Descriptor descriptor = spy(Descriptor.class);
     when(descriptor.getVariable("slim.flags")).thenReturn(null);
 
+    FixtureInteraction interaction = captureInteraction(descriptor);
+
+    assertNotNull(interaction);
+    assertEquals(DefaultInteraction.class, interaction.getClass());
+  }
+
+  private FixtureInteraction captureInteraction(Descriptor descriptor) {
     InProcessSlimClientBuilder slimClientBuilder = spy(new InProcessSlimClientBuilder(descriptor));
 
-    // Capture the interaction to see if it's the right one
     ArgumentCaptor<FixtureInteraction> interactionCaptor = ArgumentCaptor.forClass(FixtureInteraction.class);
 
     slimClientBuilder.build();
     verify(slimClientBuilder).createSlimServer(interactionCaptor.capture(), anyInt(), anyBoolean());
-    FixtureInteraction interaction = interactionCaptor.getValue();
-
-    assertNotNull(interaction);
-    assertEquals(DefaultInteraction.class, interaction.getClass());
+    return interactionCaptor.getValue();
   }
 }


### PR DESCRIPTION
The [FitNesseRunner](https://github.com/unclebob/fitnesse/blob/master/src/fitnesse/junit/FitNesseRunner.java) class does not allow test suites to be run if they make use of Fixture Interactions. This is due to the InProcessSlimClientBuilder ignoring the interaction property.

This PR contains a fix for this.